### PR TITLE
refactor : API 패턴 변경

### DIFF
--- a/src/api/issue.ts
+++ b/src/api/issue.ts
@@ -1,5 +1,6 @@
-import { client } from '.';
 import { Endpoints } from '@octokit/types';
+
+import { client } from './';
 
 export type IssueData = Endpoints['GET /repos/{owner}/{repo}/issues']['response']['data'][0];
 
@@ -7,7 +8,7 @@ const OWNER = 'facebook';
 const REPO = 'react';
 export const PER_PAGE = 30;
 
-export async function fetchGithubIssues(page = 1, owner = OWNER, repo = REPO) {
+export async function fetchGithubIssues(page = 1, owner = OWNER, repo = REPO): Promise<IssueData[]> {
   const params = {
     state: 'open',
     sort: 'comments',
@@ -15,11 +16,11 @@ export async function fetchGithubIssues(page = 1, owner = OWNER, repo = REPO) {
     per_page: PER_PAGE,
   };
 
-  const result: IssueData[] = await client.get(`/repos/${owner}/${repo}/issues`, { params }).then((res) => res.data);
-  return result;
+  const response = await client.get(`/repos/${owner}/${repo}/issues`, { params });
+  return response.data;
 }
 
-export async function fetchIssue(number: string, owner = OWNER, repo = REPO) {
-  const result: IssueData = await client.get(`/repos/${owner}/${repo}/issues/${number}`).then((res) => res.data);
-  return result;
+export async function fetchIssue(number: string, owner = OWNER, repo = REPO): Promise<IssueData> {
+  const response = await client.get(`/repos/${owner}/${repo}/issues/${number}`);
+  return response.data;
 }


### PR DESCRIPTION
## 작업 내용
- api 함수에서 `async-await` 패턴인데 Promise.then 과 혼용해서 사용해서 이 부분 수정하고 타입도 지정했습니다.

--- 
추가로 
`qs.strinfy` 로 query 부분 수정하려고 했는데 axios option 으로 param 으로 넘겨줘도 좋다고 생각되어 수정하지 않았습니다.
`qs.strinfy` 했을 때 undefined 면 속성이 추가가 안되는데 params 도 undefined 인 속성이 있으면 추가되지 않아서 params로 전달하는 방식 유지했습니다.